### PR TITLE
FIP-0032 final draft

### DIFF
--- a/FIPS/fip-0032.md
+++ b/FIPS/fip-0032.md
@@ -309,7 +309,7 @@ op_ipld_blockstat := p_syscall_gas
 
 Operations that have the potential of either underflowing or overflowing should be performed
 using [saturation arithmetic](https://en.wikipedia.org/wiki/Saturation_arithmetic). The valid
-range for any fuel operation, including total fuel consumed, is [0, 2<sup>64</sup>-1]. 
+range for any execution units operation, including total execution units consumed, is [0, 2<sup>64</sup>-1]. 
 
 The valid range for any gas operation, including gas available and total gas
 used, is [0, 2<sup>63</sup>-1]. Gas operations only go up to 2^63-1 because they
@@ -369,9 +369,8 @@ Refer to test plan laid out in [FIP-0031].
 
 ## Security Considerations
 
-With the introduction of these new gas charges, execution is now priced more
-accurately with regards to the baseline parameters, which translates into higher
-network security.
+Metering and pricing execution enables more precise gas accounting, which
+translates into higher network security.
 
 Note that this FIP alone is insufficient to secure the network for
 user-programmed actors; it is merely a stepping stone. A future FIP will
@@ -383,10 +382,12 @@ programmability.
 The gas utilization of all messages will increase, except for value transfers
 which are unaffected.
 
-A detailed breakdown of net utilization increase (relative to original gas) per
-message type has been included in Annex A; this is the result of backtesting the
-new model against 2.5MM mainnet messages. The final absolute gas used values are
-in included in Annex B.
+In order to quantify the magnitude of change, we have backtested this model
+against 2.5MM mainnet messages.
+
+- Annex A includes a detailed breakdown of net utilization increase per message
+  type (relative to original gas).
+- Annex B includes the final total gas per message type.
 
 On average, most message types increase their utilization between 1.5-3x. The
 gas performance of specific messages types is subject to various factors. The

--- a/FIPS/fip-0032.md
+++ b/FIPS/fip-0032.md
@@ -21,229 +21,289 @@ replaces: N/A
 
 This FIP is part of a two-FIP series that adjust the gas model of the Filecoin
 blockchain in preparation of user-programmable actors. This FIP focuses on
-attaining high-fidelity gas accounting under the Wasm runtime that built-in
-system actors will migrate to as part of FIP-0030 and FIP-0031. It does not
-cover upcoming system features like actor deployment, actor loading, memory
-management, and more. Those will be addressed in a subsequent FIP that focuses
-on gas model changes to support user-programmability.
+achieving high-fidelity gas accounting under the new Wasm runtime that built-in
+system actors will migrate to as part of [FIP-0030] and [FIP-0031]. It does not
+cover upcoming system features like actor deployment, actor dispatch, actor
+loading, memory management, and more. Those will be covered in a future FIP.
 
 ## Abstract
 
+The current gas model was designed to cover the execution of predefined, trusted
+code developed by the Filecoin Core Devs.
+
 With the arrival of the Filecoin Virtual Machine, the Filecoin network will gain
-the capability to run untrusted code in the form of user-defined actors.
-However, the current gas model is designed strictly for predefined, trusted
-code. In order to maintain network security guarantees, the gas model needs to
-evolve to accurately charge for computational instructions and resource usage of
-actor logic.
+the capability to run untrusted code in the form of user-defined actors. Thus,
+the gas model needs to evolve to price arbitrary code.
 
-This FIP expands the current gas model by introducing a new gas category to
-account for the real compute cost of the logic performed by every actor in the
-system. It also rearchitects IPLD state management gas, adjusts the actor call
-fee to account for Wasm invocation container mechanics, and revises the fees for
-syscalls that traverse the extern boundary (FVM <> Node).
+This FIP evolves the current gas model by introducing the concepts of _execution
+gas_, _syscall gas_, and _extern gas_. Furthermore, this FIP revises the IPLD
+state management fees to adapt to the new design.
 
-This is the first FIP out of a two-FIP series to revise the gas model as a
-result of the introduction of the Filecoin Virtual Machine.
-
-This FIP is designed to accompany FIP-0030 and FIP-0031 under the same network 
-upgrade. Taken together, these three FIPs represent the theory and process of 
-change for introducing an FVM with non-programmable smart contracts. 
-
-The second gas change FIP will be proposed and considered at a later date in 
-order to support the introduction of user-programmable smart contracts during 
-phase 2 of FVM roll-out. 
+This FIP is designed to accompany [FIP-0030] and [FIP-0031] under the same network
+upgrade (Milestone 1 of the FVM roadmap).
 
 ## Change Motivation
 
 Gas is an essential mechanism to (a) compensate the network for the computation
-performed during transaction execution, and to (b) restrict the compute capacity
-of blocks to achieve a designated epoch time (30 seconds).
+performed during the execution of transactions, (b) allocate chain bandwidth,
+and to (c) restrict the compute capacity of blocks so that the designated epoch
+time (30 seconds) can be sustained with contemporary hardware.
 
-Today, Filecoin determines the amount of gas a transaction consumes by
-intercepting specific operations and actions, and applying gas explicit gas
-charges on them. Concretely:
+Today, transactions on the Filecoin network are charged gas on these operations:
 
-- On including a chain message, variable on the length of the message.
-- On returning a value, variable on the length of returned payload.
-- On performing a call, dependent on the type of call (simple value transfer, or
-  other).
-- On performing an IPLD store get, fixed amount.
-- On performing an IPLD store put, variable on block payload size.
-- On actor creation, fixed amount.
-- On actor deletion, fixed amount.
+- On including a chain message (variable gas units, based on length).
+- On returning a value (variable gas units, based on length of returned
+  payload).
+- On performing a call (variable gas units, depending on whether it's a simple
+  value transfer, or an invocation to actor logic).
+- On performing an IPLD store get (fixed gas units).
+- On performing an IPLD store put (variable gas units, based on block payload
+  size).
+- On actor creation (fixed gas units).
+- On actor deletion (fixed gas units).
 - On cryptographic operations:
-    - On signature verification, variable on signature type and plaintext
-      length.
-    - On hashing, fixed price.
-    - On computing the CID of an unsealed sector, variable on proof type and
-      piece characteristics.
-    - On verifying a seal, variable on the seal characteristics.
-    - On verifying a window PoSt, variable on the PoSt characteristics.
+    - On signature verification (variable gas units, depending on signature type
+      and plaintext length).
+    - On hashing (fixed gas units).
+    - On computing the CID of an unsealed sector (variable gas units, based on
+      proof type and piece properties).
+    - On verifying a seal (variable gas units, based on seal properties).
+    - On verifying a window PoSt (variable gas units, based on PoSt properties).
     - On verifying a consensus fault.
 
-None of these gas charges accounts for the costs of the execution of the actor’s
-compute logic itself. This results in an incomplete resource accounting model.
-So far, the network has coped without it because:
+None of these gas charges accounts for the actual costs of the execution of the
+actor's compute logic itself. This results in an imprecise resource accounting
+system. So far, the network has coped without it because:
 
-1. The cost of built-in actor logic is negligible when compared to the cost of
-   the above operations, most of which are triggered through syscalls.
+1. With the exception of some methods, the cost of most built-in actor logic is
+   negligible when compared to the cost of the above operations, most of which
+   are triggered through syscalls.
 2. Only pre-determined, trusted logic runs on chain in the form of built-in
    actors.
-3. Technical limitations. Prior to the FVM (FIP-0030, FIP-0031), there was no
+3. Technical limitations. Prior to the FVM ([FIP-0030], [FIP-0031]), there was no
    portable actor bytecode whose execution could be metered identically across
    all implementations.
 
 With the ability to deploy user-defined actors on the FVM, these assumptions no
-longer stand and it becomes important to start tracking real execution costs
-with the highest fidelity possible, to preserve security guarantees, and to
-compensate the network for the logic it executes.
+longer stand and it's vital to start tracking real execution costs with the
+highest fidelity possible in order to preserve security guarantees.
 
 ## Specification
 
-Here’s an overview of proposed changes to the existing gas model. We explain
+Here's an overview of proposed changes to the existing gas model. We explain
 each one in detail in the following sections.
 
-- Introduce Wasm bytecode-metered execution gas.
-- Adjust the *actor call* fee, to account for new call dispatch overhead.
-- Rearchitect the IPLD state IO fees.
-- Revise fees for extern-traversing syscalls.
+- Introduce execution gas, metered by Wasm bytecode.
+- Introduce syscall gas.
+- Introduce extern gas.
+- Redesign the IPLD state management fees.
 
-### Wasm bytecode-metered execution gas
+### Execution gas
 
-We introduce a new category of gas. Execution gas is charged per Wasm
-instruction. Every Wasm instruction has a predefined amount of execution units
-associated with it.
+Execution gas is charged per [Wasm instruction][wasm-instructions]. Every Wasm
+instruction expends a number of execution units, which can be static or dynamic
+based on its parameters.
 
-Every Wasm instruction expends a flat 1 execution unit, except the following
-structural Wasm instructions: `nop`, `drop`, `block`, `loop`, `unreachable`,
-`return`, `else`  and `end` . These instructions expend 0 execution units
-because either they do not translate into machine instructions by themselves, or
-they are control flow instructions with no logic to evaluate.
-
-**Pricing formula**
-
-The conversion of Wasm execution units to Filecoin gas units is at a predefined
-ratio of `<<TODO: currently benchmarking>>`. This equivalence has been
-calculated by performing extensive benchmarks, with the goal of honouring the
-invariant baseline target of 10 gas units/ns of wall clock time[^1].
-
-Both the pricing policy for Wasm instructions and the conversion rate need to be
-assessed and revised continuously as technology improves (e.g. Wasm compilers
-and processors). The ongoing goal is to sustain high execution fidelity.
-
-### Call gas fee
-
-In Filecoin network version 15 and earlier, the call gas fee is higher for value
-transfers than it is for actor code invocations. This may sound
-counterintuitive, but it follows the fact that the call fee has to cover the
-full validation and state update cost of the transaction, because these
-transactions don’t invoke actor code. Conversely, the call fee for an actor
-invocation represents only the dispatch effort, hence why it’s lower.
-
-With FVM actors, the call cost structure changes. For actor code invocations, a
-Wasm-based invocation container needs to be instantiated, and parameters need to
-be serialized and inserted into the IPLD blockstore. In other words, there is
-more work to do that than previously, and therefore the fee is adjusted upward.
+As part of this FIP, we assign a flat value of 1 execution unit for every Wasm
+instruction, with the exception of structural instructions. These instructions
+are: `nop`, `drop`, `block`, `loop`, `unreachable`, `return`, `else` and `end`.
+The exemption is due to the fact that these Wasm instructions do not translate
+into machine instructions by themselves, or they are control flow instructions
+with no associated logic.
 
 **Pricing formula**
 
+The conversion of Wasm execution units to Filecoin gas units is at a fixed ratio
+of 4gas per execution unit.
+
+This ratio is consistent with the average instruction throughput observed in
+benchmarks, and tracks the baseline target of 10 gas units/ns of wall clock
+time.
+
 ```
-TODO: benchmarking
+p_gas_per_exec_unit := 4
 ```
 
-### IPLD state management fees
+**Future considerations**
 
-Currently, IPLD block read incur a fixed fee, and IPLD block writes incur a
-variable fee, dependent on the number of bytes written.
+1. Our benchmarks revealed that memory instructions perform differently to pure
+   CPU-level instructions. They also exhibit high variance depending on the
+   memory access pattern of the actor, CPU caching dynamics, and other factors.
+   At this stage, we have opted to simplify the model by setting a fixed average
+   rate for all instructions. But in the future, we may tabulate execution gas
+   per instruction, or per instruction family.
+2. The pricing policy for Wasm instructions and the conversion rate need to be
+   assessed and revised continuously as Wasm compilers and hardware evolve. The
+   ongoing goal is to sustain high execution fidelity.
 
-With the FVM, IPLD state I/O is managed through five syscalls, with the
-specified overhead and pricing. We introduce a `block_memcpy_per_byte` cost for those
-operations that involve a memcpy. The overhead and pricing are as follows:
+### Syscall gas
 
-**Overhead**
+Syscalls are host-provided functions exposed to actor code. They allow the actor
+to traverse the sandbox in a controlled manner to:
 
-- `block_open`: looks up the supplied CID, loads the block from the state
-  blockstore into the FVM kernel’s block cache, reports its size and codec. It
-  returns a numeric block handle.
-    - Overhead: This syscall traverses the FVM<>client boundary via an extern in
-      order to query the state blockstore. This leads to disk IO with associated
-      read amplification. The bytes returned through the extern are copied into
-      the FVM’s memory so that the buffer can be reclaimed by the client side;
-      thus there is an alloc and memcpy cost. The bytes are retained in memory
-      until the actor call finishes and the invocation container is dropped, and
-      thus the actor is charged for this memory usage.
-- `block_read`: takes a block handle and an output buffer, and copies the
-  block’s data from the FVM kernel’s block cache into the actor’s memory.
-    - Overhead: This syscall resolves inside the FVM and doesn’t traverse the
-      FVM<>node boundary. The overhead is that of a memcpy operation.
-- `block_write`: takes some block data and a codec, and merely copies it to the
-  FVM kernel’s block cache. It returns a numeric block handle.
-    - Overhead: This syscall resolves inside the FVM and doesn’t traverse the
-      FVM<>node boundary. It involves a memcpy to a buffer that is retained
-      until the actor call finishes. The bytes are retained in memory until the
-      actor call finishes and the invocation container is dropped, and thus the
-      actor is charged for this memory usage.
-- `block_link`: computes the CID of a block, and commits the block to the state
-  blockstore.
-    - Overhead: This syscall traverses the FVM<>client boundary via an extern in
-      order to write to the state blockstore (although this is deferred until
-      the machine flush). This leads to disk IO with associated write
-      amplification. The bytes are copied over to the client’s memory, thus
-      there is an alloc and memcpy cost. Computing the CID involves a hashing
-      operation (akin to the hash syscall, but without the syscall overhead).
-      Because the CID is returned to the actor via an output buffer, there is
-      another memcpy involved.
-- `block_stat`: returns the length and the codec of a block.
-    - Overhead: This syscall resolves inside the FVM and doesn’t traverse the
-      FVM<>node boundary. It performs a map lookup and returns an integer tuple.
+- access data (e.g. state data, chain data, randomness).
+- perform side effects (e.g. write to state).
+- invoke operations that are more efficient to implement in native space than in
+  Wasm (e.g. cryptograhic primitives).
 
-**Pricing formulae**
+Calling a syscall triggers a context switch out, and back in when execution
+returns to Wasm. The syscall gas merely covers this overhead. It does not price
+the actual work performed by the syscall; that work is charged for separately,
+and is specific to every syscall.
 
-- `block_open` (extern-traversing): `block_open_base + block_open_per_byte * len`
-- `block_read`: `block_read_base + block_memcpy_per_byte * len`
-- `block_write`: `block_create_base + block_memcpy_per_byte * len`
-- `block_link` (extern-traversing): `block_link_base + block_link_per_byte * storage_gas_multiplire * len`
-- `block_stat`: `block_stat` (fixed cost)
+**Pricing formula**
 
-### Extern-traversing syscall fee revision
+We have quantified the average context switch overhead to be equivalent to 3500
+execution units. At the rate of 4 gas per execution unit, we set the syscall gas
+price to be 14000 gas.
 
-Some syscalls cannot be resolved entirely within FVM space. Such syscalls
-need to traverse the "extern" (FVM<>node) boundary to access client
-functionality.
+```
+p_syscall_gas := 14000
+```
+
+**Future considerations**
+
+The cost of syscall-driven context switches varies depending on the syscall, its
+parameters, the amount of work it performs (thus invalidating CPU caches and
+instruction pipeline), and other factors. In the future, we may tabulate syscall
+gas depending on the complexity of the syscall, its arguments, its impact on CPU
+optimizations, and more.
+
+### Extern gas
+
+Some syscalls cannot be resolved entirely within FVM space. Such syscalls need
+to traverse the _extern_ (FVM <> Node) boundary to access client functionality.
 
 Depending on the languages of the client and the FVM implementation, traversing
-this boundary may involve foreign-function interface (FFI) mechanics.
+this boundary may involve foreign-function interface (FFI) mechanics. That is
+indeed the case with the reference client (Lotus) and the reference FVM
+(ref-fvm). This is the most common scenario today given the client distribution
+of the network.
 
-That is indeed the case with the reference client (Lotus) and the reference FVM
-(ref-fvm). Not only is this the worst case scenario, but it's the most common
-scenario today given the client distribution of the network.
+The associated overheads are:
 
-In accordance to the design principle of high-execution fidelity, we propose
-that the gas fees account for the cost of the FFI boundary.
-
-The associated costs are:
-
-- data structure translation between representations, including serialization
-  costs.
+- data structure translation between representations, including potential
+  serialization overheads.
 - context switch.
 - the memory overhead on both sides of the interface.
-- the amortized (opportunity) cost of dedicating OS threads.
+- the amortized opportunity cost of dedicating OS threads to handle FFI calls.
 - the amortized garbage collection or deallocation costs once the extern
   concludes.
 - function lookup and dispatch.
 
 **Pricing formulae**
 
-The pricing formulae for extern-traversing syscalls are:
+Extern gas is priced at 1.5x syscall gas. It is equivalent to a flat 5250
+execution units, and therefore it costs 21000 gas. Extern gas is additive to
+syscall gas.
 
-- `get_chain_randomness`: `<<TODO>>`
-- `get_beacon_randomness`: `<<TODO>>`
-- `verify_consensus_fault`: `<<TODO>>`. This is a fixed cost that covers all blockstore operations,
-  signature verifications, and other logic needed to resolve whether a consensus fault has occured.
-  Note that differs from network v15 and earlier, where the cost is variable depending on the exact
-  blockstore operations performed.
-- Blockstore operations: already absorbed in the fees specified above ("IPLD
-  state management fees").
+```
+p_extern_gas := 21000
+```
+
+The following syscalls are extern-traversing syscalls, and therefore are subject
+to extern gas:
+
+- `rand::get_chain_randomness`.
+- `rand::get_beacon_randomness`.
+- `crypto::verify_consensus_fault`.
+- `ipld::block_open`.
+
+### IPLD state management gas
+
+Currently, IPLD state block operations incur these fees:
+
+- Reads incur a fixed fee.
+- Writes incur a variable fee, based on the number of bytes written.
+
+With the introduction of the FVM, the state management operations have evolved
+from a two-method design to five syscalls:
+
+- `ipld::block_open`
+- `ipld::block_read`
+- `ipld::block_write`
+- `ipld::block_link`
+- `ipld::block_stat`
+
+For more details, refer to `ipld` namespace syscall catalogue in
+[FIP-0030](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0030.md#namespace-ipld).
+
+**memcpy per byte gas charge**
+
+We introduce a gas charge for memcpy'ing bytes across system boundaries
+(`p_memcpy_gas_per_byte`). The fee is 500 milligas per byte, resulting from
+statistics collected on average memcpy latencies, adapted to the Filecoin gas
+sizing baseline (10gas per ns).
+
+```
+p_memcpy_gas_per_byte := 0.5
+```
+
+**Pricing for `ipld::block_open`**
+
+_Overhead:_ This syscall traverses the FVM <> Node boundary via an extern to
+access the state blockstore. The bytes returned through the extern are copied
+into FVM kernel buffers; thus there is an memcpy and alloc cost (the latter is
+absorbed into the former). The kernel buffers are retained until the actor call
+finisihes.
+
+The pricing formula is:
+
+```
+p_blockopen_base_gas := 114617   # extant fee
+op_ipld_blockopen := p_syscall_gas + p_extern_gas + p_blockopen_base_gas + (p_memcpy_gas_per_byte * block_length)
+```
+
+**Pricing for `ipld::block_read`**
+
+_Overhead:_ This syscall performs an memcpy from the FVM kernel's buffers to
+Wasm memory.
+
+The pricing formula is:
+
+```
+op_ipld_blockread := p_syscall_gas + (p_memcpy_gas_per_byte * byte_length)
+```
+
+**Pricing for `ipld::block_write`**
+
+_Overhead:_ This syscall performs an memcpy from Wasm memory into the FVM
+kernel's buffers, with a corresponding alloc (absorbed into the memcpy cost).
+The kernel buffers are retained until the actor call finishes.
+
+The pricing formula is:
+
+```
+op_ipld_blockwrite := p_syscall_gas + (p_memcpy_gas_per_byte * byte_length)
+```
+
+**Pricing for `ipld::block_link`**
+
+_Overhead:_ This syscall incurs a hashing operation to compute the CID of the
+block. It then copies it over to the buffered blockstore, where it is retained
+until the Machine is flushed and the blocks are written to the Node's blockstore
+via an extern. Because the extern is invoked by the system, the actor is not
+charged for it.
+
+The pricing formula for compute gas is:
+
+```
+p_blocklink_base_gas := 353640    # extant fee
+p_storage_gas_multiplier := 1300  # extant fee
+op_ipld_blocklink_compute := p_syscall_gas + p_blocklink_base_gas + (p_memcpy_gas_per_byte * byte_length * 2)
+op_ipld_blocklink_storage := p_storage_gas_multiplier * byte_length
+op_ipld_blocklink := op_ipld_blocklink_compute + op_ipld_blocklink_storage
+```
+
+**Pricing for `ipld::block_stat`**
+
+No relevant overhead.
+
+The pricing formula is:
+
+```
+op_ipld_blockstat := p_syscall_gas
+```
 
 ### Under/overflow handling
 
@@ -251,60 +311,135 @@ Operations that have the potential of either underflowing or overflowing should 
 using [saturation arithmetic](https://en.wikipedia.org/wiki/Saturation_arithmetic). The valid
 range for any fuel operation, including total fuel consumed, is [0, 2<sup>64</sup>-1]. 
 
-The valid range for any gas operation, including gas available and total gas used, is 
-[0, 2<sup>63</sup>-1]. Gas operations only go up to 2^63-1 because they are performed using
-signed arithmetic. This is because the Filecoin protocol has some gas costs that are negative as 
-of nv15.
+The valid range for any gas operation, including gas available and total gas
+used, is [0, 2<sup>63</sup>-1]. Gas operations only go up to 2^63-1 because they
+are performed using signed arithmetic. This is because the Filecoin protocol has
+some gas costs that are negative as of nv15.
 
 ## Design Rationale
 
-To simplify community discussion and align with the FVM deployment roadmap, all
-changes related to new system features related to user-programmable actors are
-kept out of scope of this FIP. This set of changes covers only the technological
-transition to a Wasm runtime for built-in actors. This FIP will be followed by
-another FIP introducing the former.
+### Gas sizing baseline
 
-Concerning the design of each individual change, the specification section
-elaborates on overhead that is being accounted for and the variables that make
-up every pricing formula.
+We use a baseline of 10 gas/nanosecond of wall-clock time. This baseline follows
+from the need to sustain a 30s epoch by validating and applying unique messages
+in a tipset, with a block count following a Poisson distribution (win rate),
+with a 10B block gas limit, assuming 6s of block propagation time.
+
+### Benchmark methodology
+
+The parameters for this FIP were calculated through extensive benchmarking using
+three profiling techniques to obtain a performance data from various vantage
+points:
+
+1. Fine-grained tracing of 2.5MM mainnet message applications.
+2. Aggregated execution statistics of 2.5MM mainnet messages.
+3. Raw Wasmtime micro-benchmarks.
+
+The machines had the following specs: 1 x AMD EPYC 7402P, 24 cores @ 2.8 GHz, 2
+x 240GiB SSD (boot), 2 x 480GiB SSD (storage), 64GiB DDR4 RAM, running Debian
+4.19.208-1.
+
+The code assets for (1) and (2) are available at
+[filecoin-project/ref-fvm#465](https://github.com/filecoin-project/ref-fvm/pull/465).
+
+The raw Wasmtime micro-benchmarker is available at
+[filecoin-project/ref-fvm#502](https://github.com/filecoin-project/ref-fvm/pull/502).
+
+Benchmarking overheads were measured and corrected for in the data.
 
 ## Backwards Compatibility
 
-The data model by which gas allowance and usage is represented in external
-interfaces (gas limit, gas used, etc.) remains unchanged. However, the same
-transaction made before and after this FIP will, with very high likelihood,
-result in different values for *gas used*. Transactions sitting in the mempool
-at the activation epoch of this FIP will need to be re-estimated and replaced.
+External-facing gas representation (gas limit, gas used, etc.) remains
+unchanged.
+
+However, the gas usage of most messages will increase upwards, so systems using
+static gas limits should be adapted accordingly.
+
+Clients sending messages near the activation epoch of this FIP should estimate
+gas under the new pricing model to guarantee inclusion.
+
+- If the message is included pre-activation, the message will result in a higher
+  overestimation burn.
+- If the message is included post-activation, the message will be executed
+  normally.
 
 ## Test Cases
 
-Testing for this FIP involves two efforts:
-
-1. An updated corpus of FVM-compatible [test
-   vectors](https://github.com/filecoin-project/fvm-test-vectors) with the new
-   gas model.
-2. The testnet plan laid out in FIP-0031.
+Refer to test plan laid out in [FIP-0031].
 
 ## Security Considerations
 
-TODO draft.
+With the introduction of these new gas charges, execution is now priced more
+accurately with regards to the baseline parameters, which translates into higher
+network security.
+
+Note that this FIP alone is insufficient to secure the network for
+user-programmed actors; it is merely a stepping stone. A future FIP will
+introduce further the final gas model changes before enabling user
+programmability.
 
 ## Incentive Considerations
 
-With the introduction of execution gas to account for real execution cost, actor
-compute logic will no longer be exempted from gas charges, thus resulting in a
-net increase in gas expenditure in the network.
+The gas utilization of all messages will increase, except for value transfers
+which are unaffected.
+
+A detailed breakdown of net utilization increase (relative to original gas) per
+message type has been included in Annex A; this is the result of backtesting the
+new model against 2.5MM mainnet messages. The final absolute gas used values are
+in included in Annex B.
+
+On average, most message types increase their utilization between 1.5-3x. The
+gas performance of specific messages types is subject to various factors. The
+reader is advised to study Annex A to understand the variability involved.
+
+In our backtest, the four most important messages for storage provider
+operations were impacted in this manner:
+
+- SubmitWindowPoSt (miner actor): gas usage increases an average of 3x, with a
+  median of 2.73x, and a 90% percentile score of 4.42x. Some executions spiked
+  as much as 14x.
+- PreCommitSector (miner actor): gas usage increases an average of 3x, with a
+  median of 2.37x, and a 90% percentile score of 5x. Some executions spiked as
+  much as 9x.
+- ProveCommitSector (miner actor): gas usage increases an average of 1.21x, with
+  an identical median, and a 90% percentile score of 1.26x. Some executions
+  spiked as much as 2.7x.
+- PublishStorageDeals (market actor): gas usage increases an average of 1.71x,
+  with a median of 1.75x, and a 90% percentile score of 1.92x. Some executions
+  spiked as much as 2x.
+
+These two message types deserve special attention.
+
+- DeclareFaultsRecovered (miner actor): highest variability between executions
+  and highest multiplier; on average, gas cost increases 8x, with some instances
+  spiking as much as 30x in the backtest. All executions were within the block
+  gas limit.
+- ExtendSectorExpiration (miner actor): infrequent; was already an expensive
+  message. Some executions lead to gas usage beyoned the block limit, rendering
+  them inviable (up to 2.2e10 gas). However, this is a batched message, so
+  clients should size batches within gas limits.
+
+On average, we observe a global increase of 1.87x in gas utilization, if the
+current chain activity were to remain unchanged. However, the HyperDrive upgrade
+introduced power onboarding batching mechanisms in [FIP-0008] and [FIP-0013]
+that have stayed underutilized. We expect these to kick in an adaptive response
+to lower usage and increase chain bandwidth again.
+
+At last, we expect higher upwards pressure on the base fee, due to two factors:
+
+- higher chain bandwidth utilization.
+- message executions more frequently surpassing the base fee target (50% of
+  block gas limit, i.e. 5B).
 
 ## Product Considerations
 
-The cost every actor method changes upwards as a result of this FIP.
-Furthermore, by charging for actor logic itself, methods that are more
-computationally intensive may have their price structure changed significantly.
-These two implications may transpire as changes in onboarding, power maintenance,
-deal-making, and other features that are noteworthy from a product perspective.
-
-`<<TODO: More data will be added to this section once benchmarking has been
-completed>>.`
+1. Messages get more expensive. See Incentive Considerations section for a
+   synthesis, and Annex A and Annex B for raw data.
+2. Potential for higher community motivation to optimize built-in actors logic,
+   as doing so directly translates into cost reductions.
+3. Messages estimated pre-FVM will likely not be executed post-FVM. See
+   Backwards Compatibility section for ways to mitigate.
+4. Some batch-
 
 ## Implementation
 
@@ -313,21 +448,83 @@ For clients relying on the reference FVM implementation
 implementation of this FIP will be transparent, as it is self-contained inside
 the FVM.
 
+## Annex A: Table of gas utilization increase per message type
+
+|                        |        | gas\_utilization\_increase |             |                |             |             |             |             |             |             |             |             |             |
+| ---------------------- | ------ | -------------------------- | ----------- | -------------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- |
+|                        |        | count                      | mean        | std            | min         | 50%         | 60%         | 70%         | 80%         | 90%         | 95%         | 99%         | max         |
+| code                   | method |                            |             |                |             |             |             |             |             |             |             |             |             |
+| fil/7/account          | 0      | 45875                      | 1.005917762 | 0.02417353413  | 1           | 1           | 1           | 1           | 1           | 1           | 1.104362264 | 1.104684688 | 1.115612956 |
+| fil/7/init             | 2      | 6                          | 1.424152199 | 0.003497993647 | 1.420961258 | 1.423357446 | 1.424705436 | 1.425673293 | 1.426641151 | 1.42812825  | 1.428871799 | 1.429466639 | 1.429615349 |
+| fil/7/multisig         | 0      | 111                        | 1           | 0              | 1           | 1           | 1           | 1           | 1           | 1           | 1           | 1           | 1           |
+| fil/7/multisig         | 2      | 1838                       | 1.49888439  | 0.1256852181   | 1.455639985 | 1.470335469 | 1.470415198 | 1.470625796 | 1.471129685 | 1.481508548 | 1.587097983 | 2.20239369  | 2.351119604 |
+| fil/7/multisig         | 3      | 467                        | 1.983014254 | 0.4273290074   | 1.401773916 | 1.916782957 | 1.969174962 | 2.249158069 | 2.453986925 | 2.676459729 | 2.740818207 | 2.837620526 | 2.957000268 |
+| fil/7/multisig         | 4      | 1                          | 1.541821859 |                | 1.541821859 | 1.541821859 | 1.541821859 | 1.541821859 | 1.541821859 | 1.541821859 | 1.541821859 | 1.541821859 | 1.541821859 |
+| fil/7/paymentchannel   | 0      | 1                          | 1           |                | 1           | 1           | 1           | 1           | 1           | 1           | 1           | 1           | 1           |
+| fil/7/storagemarket    | 2      | 2586                       | 1.677846797 | 0.01641321941  | 1.622797511 | 1.675575666 | 1.680067456 | 1.68604039  | 1.690120693 | 1.706057689 | 1.706908548 | 1.707587268 | 1.710623822 |
+| fil/7/storagemarket    | 3      | 1                          | 1.835677528 |                | 1.835677528 | 1.835677528 | 1.835677528 | 1.835677528 | 1.835677528 | 1.835677528 | 1.835677528 | 1.835677528 | 1.835677528 |
+| fil/7/storagemarket    | 4      | 5265                       | 1.713832195 | 0.167006235    | 1.378324013 | 1.747459302 | 1.756717183 | 1.789865482 | 1.857274123 | 1.915473598 | 1.937876891 | 1.974763644 | 2.036444245 |
+| fil/7/storageminer     | 0      | 22                         | 1           | 0              | 1           | 1           | 1           | 1           | 1           | 1           | 1           | 1           | 1           |
+| fil/7/storageminer     | 3      | 33                         | 1.544150097 | 0.01762076733  | 1.516727174 | 1.538374672 | 1.552194181 | 1.553229183 | 1.55397207  | 1.57235456  | 1.572710246 | 1.579623494 | 1.582876787 |
+| fil/7/storageminer     | 4      | 56                         | 1.398619224 | 0.008946785601 | 1.37256878  | 1.399053273 | 1.402824374 | 1.403470248 | 1.405743523 | 1.406549884 | 1.406658139 | 1.415199818 | 1.415937618 |
+| fil/7/storageminer     | 5      | 217106                     | 3.001380622 | 1.291170636    | 1.073645329 | 2.731878913 | 3.112291315 | 3.497449584 | 3.903461537 | 4.423025069 | 5.164439561 | 7.807636626 | 14.46421024 |
+| fil/7/storageminer     | 6      | 1185994                    | 3.026592891 | 1.496389648    | 1           | 2.379804446 | 2.55861521  | 3.023486067 | 4.010961794 | 5.015472983 | 6.42727476  | 8.687420506 | 9.667892479 |
+| fil/7/storageminer     | 7      | 1053956                    | 1.213380855 | 0.0372125817   | 1           | 1.210958768 | 1.220186923 | 1.230795355 | 1.243780613 | 1.261473526 | 1.275400176 | 1.309423389 | 2.694420812 |
+| fil/7/storageminer     | 8      | 30                         | 2.475374133 | 0.854622837    | 1.600038973 | 2.122905573 | 2.285529193 | 2.754937489 | 3.131700562 | 4.006707012 | 4.032028248 | 4.07123791  | 4.082966433 |
+| fil/7/storageminer     | 9      | 104                        | 2.645544754 | 0.6874569231   | 1.851345598 | 2.325670753 | 2.674528085 | 3.133873234 | 3.219849741 | 3.336542645 | 3.562847759 | 5.283788788 | 5.42050949  |
+| fil/7/storageminer     | 11     | 1617                       | 7.994836886 | 7.31229865     | 1.623235513 | 3.789194292 | 4.56465667  | 9.842812607 | 16.26378321 | 21.55095991 | 22.24913297 | 25.58566865 | 30.6684894  |
+| fil/7/storageminer     | 16     | 1310                       | 2.070571714 | 0.048140412    | 1.53773354  | 2.070956394 | 2.074284782 | 2.077834587 | 2.07906097  | 2.08010869  | 2.081971072 | 2.215612748 | 2.248252248 |
+| fil/7/storageminer     | 18     | 18                         | 1.405288395 | 0.01107401339  | 1.379686399 | 1.409628134 | 1.412962602 | 1.412962602 | 1.412990164 | 1.413025152 | 1.414754664 | 1.422595114 | 1.424555227 |
+| fil/7/storageminer     | 22     | 2                          | 1.529627586 | 0.000634365616 | 1.529179022 | 1.529627586 | 1.529717299 | 1.529807012 | 1.529896725 | 1.529986437 | 1.530031294 | 1.530067179 | 1.53007615  |
+| fil/7/storageminer     | 23     | 37                         | 1.407758291 | 0.006237523785 | 1.389591234 | 1.409438265 | 1.409447888 | 1.409982494 | 1.411901489 | 1.415315811 | 1.415396266 | 1.416970863 | 1.41776426  |
+| fil/7/storageminer     | 25     | 7485                       | 2.691826778 | 0.8558509903   | 1           | 2.321657516 | 2.494654692 | 2.730209544 | 2.95191148  | 3.338231379 | 4.875076008 | 5.925291961 | 8.682704739 |
+| fil/7/storageminer     | 26     | 5812                       | 1.824601816 | 0.3903509537   | 1           | 1.809926428 | 2.008929727 | 2.153521744 | 2.210637829 | 2.34720221  | 2.420199167 | 2.594294262 | 3.067947064 |
+| fil/7/storageminer     | 27     | 81                         | 1.658007365 | 0.125914532    | 1.586545298 | 1.622265586 | 1.627453668 | 1.630537788 | 1.644412417 | 1.735504031 | 1.83589129  | 2.054537246 | 2.608683685 |
+| fil/7/storagepower     | 2      | 34                         | 1.407148482 | 0.006099455023 | 1.396422735 | 1.406812581 | 1.408610707 | 1.409677967 | 1.412416786 | 1.413962019 | 1.416608818 | 1.421315733 | 1.421459694 |
+| fil/7/verifiedregistry | 4      | 11                         | 1.708255928 | 0.03427059356  | 1.613045556 | 1.715087058 | 1.727790793 | 1.727790793 | 1.728131584 | 1.728131584 | 1.732089921 | 1.735256591 | 1.736048258 |
+
+## Annex B: Table of total final gas used per message type
+
+|                        |        | final\_total\_gas |                   |                   |                   |                   |                   |                   |                   |                   |                   |                   |
+| ---------------------- | ------ | ----------------- | ----------------- | ----------------- | ----------------- | ----------------- | ----------------- | ----------------- | ----------------- | ----------------- | ----------------- | ----------------- |
+|                        |        | mean              | std               | min               | 50%               | 60%               | 70%               | 80%               | 90%               | 95%               | 99%               | max               |
+| code                   | method |                   |                   |                   |                   |                   |                   |                   |                   |                   |                   |                   |
+| fil/7/account          | 0      | 579409.7915       | 429519.4004       | 278696            | 491868            | 491868            | 491868            | 493168            | 495768            | 2324166           | 2330666           | 2.41E+06          |
+| fil/7/init             | 2      | 17781412.17       | 696179.9125       | 16623282          | 18086790.5        | 18176750          | 18247688          | 18318626          | 18324294          | 18327128          | 18329395.2        | 1.83E+07          |
+| fil/7/multisig         | 0      | 443475.2072       | 23048.51686       | 415168            | 441168            | 441168            | 442468            | 443768            | 493168            | 493168            | 493168            | 4.94E+05          |
+| fil/7/multisig         | 2      | 5718685.411       | 2208331.469       | 3505155           | 5551322           | 5551430           | 5555010           | 5559042           | 5563194           | 5602762.4         | 16927459.03       | 2.86E+07          |
+| fil/7/multisig         | 3      | 13089448.95       | 11295552.62       | 980841            | 7875274           | 11594475.8        | 13273839.4        | 24268318.4        | 33403239.4        | 39205587.9        | 43247276.94       | 4.68E+07          |
+| fil/7/multisig         | 4      | 1963800           |                   | 1963800           | 1963800           | 1963800           | 1963800           | 1963800           | 1963800           | 1963800           | 1963800           | 1.96E+06          |
+| fil/7/paymentchannel   | 0      | 486668            |                   | 486668            | 486668            | 486668            | 486668            | 486668            | 486668            | 486668            | 486668            | 4.87E+05          |
+| fil/7/storagemarket    | 2      | 18658574.86       | 454077.0529       | 17562351          | 18544233          | 18608937          | 18941817          | 19128285          | 19358113          | 19358525          | 19620838          | 2.01E+07          |
+| fil/7/storagemarket    | 3      | 21311223          |                   | 21311223          | 21311223          | 21311223          | 21311223          | 21311223          | 21311223          | 21311223          | 21311223          | 2.13E+07          |
+| fil/7/storagemarket    | 4      | 413098051.9       | 456514759.8       | 62609741          | 274519626         | 323602629.6       | 390909198.8       | 804501094.4       | 848560675.6       | 899647959.8       | 2399155869        | 2.51E+09          |
+| fil/7/storageminer     | 0      | 440636.1818       | 33021.16762       | 417768            | 419718            | 420368            | 454038            | 488228            | 493168            | 495638            | 495768            | 4.96E+05          |
+| fil/7/storageminer     | 3      | 2970019.333       | 153251.3482       | 2839834           | 2919498           | 2935451.6         | 2945915.6         | 2976917.2         | 3289962           | 3291262           | 3366407.44        | 3.40E+06          |
+| fil/7/storageminer     | 4      | 2456042.929       | 44191.62383       | 2342681           | 2456285           | 2466749           | 2484329           | 2490017           | 2506197           | 2506217           | 2536646.8         | 2.55E+06          |
+| fil/7/storageminer     | 5      | 49325398.39       | 118929811.8       | 1232629           | 29188449          | 37883753          | 48594377          | 63468177          | 86918525          | 111985444         | 276914415.2       | 6.41E+09          |
+| fil/7/storageminer     | 6      | 56458501.82       | 63947144.45       | 335919            | 32108687.5        | 35849884          | 45418728.2        | 71098269.6        | 109499571         | 177697999.4       | 362337308.9       | 4.74E+08          |
+| fil/7/storageminer     | 7      | 63212651.66       | 10396509.62       | 2759119           | 59943629.5        | 61962740          | 64745426.5        | 69255889          | 77938907          | 86465080          | 99034156.9        | 1.16E+08          |
+| fil/7/storageminer     | 8      | 5923900902        | 8488049980        | 30109967          | 55852976          | 114347305         | 14684231504       | 15813293994       | 18256026495       | 21000904981       | 21841083236       | 2.21E+10          |
+| fil/7/storageminer     | 9      | 140124538.2       | 180483871.8       | 26287943          | 77307069          | 111148019.2       | 142634143.4       | 177574561.8       | 281637724.5       | 315400143.8       | 1078709063        | 1.46E+09          |
+| fil/7/storageminer     | 11     | 204665314.7       | 376419840.6       | 9919102           | 47424103          | 71018922.6        | 149524682         | 375670781.2       | 492306799         | 822904774.6       | 1906198407        | 3.57E+09          |
+| fil/7/storageminer     | 16     | 19651993.88       | 1888459.502       | 2248690           | 19701951          | 19825190.2        | 20041409.4        | 20197906.2        | 20293339.8        | 20369485.2        | 24298785.68       | 2.47E+07          |
+| fil/7/storageminer     | 18     | 2418888.778       | 54381.4127        | 2307709           | 2437505           | 2458993           | 2460548.2         | 2460721           | 2460745           | 2467150.8         | 2495936.56        | 2.50E+06          |
+| fil/7/storageminer     | 22     | 1882349           | 780.6458864       | 1881797           | 1882349           | 1882459.4         | 1882569.8         | 1882680.2         | 1882790.6         | 1882845.8         | 1882889.96        | 1.88E+06          |
+| fil/7/storageminer     | 23     | 2399027.162       | 39271.81082       | 2297917           | 2390897           | 2404683.4         | 2410034.6         | 2428113           | 2460138.6         | 2466193           | 2467298.92        | 2.47E+06          |
+| fil/7/storageminer     | 25     | 205075794.5       | 246405489.4       | 341119            | 129018156         | 171290249.6       | 214444773.4       | 262631188         | 528939775.8       | 821176234.2       | 1136975105        | 1.22E+09          |
+| fil/7/storageminer     | 26     | 800031825.5       | 669882830.6       | 30303519          | 500804676         | 744232712.6       | 968439482.1       | 1441497470        | 1590315837        | 2134948503        | 3211731807        | 4.46E+09          |
+| fil/7/storageminer     | 27     | 131104891.6       | 16659267          | 118694053         | 127452754         | 128680966         | 130334894         | 133403222         | 143053434         | 150992827         | 196388620         | 2.44E+08          |
+| fil/7/storagepower     | 2      | 39499528.15       | 570366.4107       | 38100738          | 39422212          | 39596833.2        | 39714364.8        | 39939416.2        | 40381566.7        | 40482234.35       | 40534859          | 4.05E+07          |
+| fil/7/verifiedregistry | 4      | 12602227          | 768599.3907       | 11795753          | 12229826          | 12230694          | 13406634          | 13406634          | 13457143          | 13674671.5        | 13848694.3        | 1.39E+07          |
+
 ## Copyright
 
 Copyright and related rights waived via
 [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
 
-## Footnotes
-
-[^1]: The baseline target itself determined by the need to sustain a 30 second
-    epoch frequency, with a 6 second block propagation time, under these
-    circumstances, which represent the absolute worst possible scenario:
-      - Block gas limit of 15B gas units.
-      - Attaining the maximum winrate at an epoch (11).
-      - No duplicated messages across blocks in a tipset.
-      - 100% saturation of every block with compute.
-
-    The choice of 10 gas units/ns as a baseline implies a block validation time
-    of 1.5s and a fully saturated tipset validation time of 16.5s (given that
-    message and block execution cannot be parallelized).
+[wasm-instructions]: https://webassembly.github.io/spec/core/syntax/instructions.html
+[FIP-0008]: https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0008.md
+[FIP-0013]: https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0013.md
+[FIP-0030]: https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0030.md
+[FIP-0031]: https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0031.md


### PR DESCRIPTION
- adds syscall gas
- adds extern gas
- adds gas parameters
- removes revision of fees for extern-traversing syscalls
- adds incentive considerations
- adds product considerations
- editorial pass (rewrite most of the FIP)